### PR TITLE
Fixing broken link to ROCm 5.7.1

### DIFF
--- a/blogs/artificial-intelligence/llama2-lora/README.md
+++ b/blogs/artificial-intelligence/llama2-lora/README.md
@@ -83,7 +83,7 @@ This example leverages two GCDs (Graphics Compute Dies) of a AMD MI250 GPU and e
 Our setup:
 
 * Hardware: AMD Instinct MI250
-* Software: [ROCm 5.7.1](https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html)
+* Software: [ROCm 5.7.1](https://rocm.docs.amd.com/en/docs-5.7.1/deploy/linux/quick_start.html)
 * Libraries: `transformers`, `accelerate`, `peft`, `trl`, `bitsandbytes`
 
 ### Step 1: Getting started


### PR DESCRIPTION
This fixes a broken link [ROCm 5.7.1] that was pointing to a 404 page (https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html).

Objective of the new blog:
Please describe the intent of the blog.

Signoff section must be completed prior to publishing.

* Technical reviewer approves publishing: (edit and replace with @githubid)
* Editorial team approved publishing: (edit and replace with @githubid)
* Blog author team signoffs
  * Legal self review traffic lights completed: (edit and replace with @githubid)
  * Licenses file included for content is correct: (edit and replace with @githubid)
  * Changes from technical review and editorial team are acceptable: (edit and replace with @githubid)
