### PR TITLE
Align hugging face link of DeepSeek V3 and its MTP module in the MTP Blog

### DIFF
--- a/blogs/software-tools-optimization/mtp/README.md
+++ b/blogs/software-tools-optimization/mtp/README.md
@@ -161,17 +161,17 @@ docker run -d -it --ipc=host --network=host --privileged \
 Please navigate to the directory where you can save the downloaded model weights. In our case, it’s the directory “/models“. Use the commands below:
 
 ```bash
-# Download DeepSeek R1 weight
+# Download DeepSeek V3 weight
 huggingface-cli download --resume-download \
     --local-dir-use-symlinks False \
-    deepseek-ai/DeepSeek-R1 \
-    --local-dir DeepSeek-R1
+    deepseek-ai/DeepSeek-V3 \
+    --local-dir DeepSeek-V3
 
 # Download NextN (MTP) weight
 huggingface-cli download --resume-download \
     --local-dir-use-symlinks False \
-    lmsys/DeepSeek-R1-NextN \
-    --local-dir DeepSeek-R1-NextN
+    lmsys/DeepSeek-V3-NextN \
+    --local-dir DeepSeek-V3-NextN
 ```
 
 ### Launch the Server


### PR DESCRIPTION
Objective of the new blog:
Please describe the intent of the blog.

As blog described, DeepSeek V3/R1 + its MTP module are both supported for SGLang with ROCm. 
It will be easier for developer to reproduce the results that we keep consistent of hugging face model of DeepSeek V3 and its MTP module in `Download the Model Weights` and `Launch the Server` section: 
- Main model: https://huggingface.co/deepseek-ai/DeepSeek-V3
- MTP module: https://huggingface.co/lmsys/DeepSeek-V3-NextN

Signoff section must be completed prior to publishing.

* Technical reviewer approves publishing: (edit and replace with @githubid)
* Editorial team approved publishing: (edit and replace with @githubid)
* Add a thumbnail image for your blog if one is available
* Text nugget summarizing your article. 2-3 lines to draw the reader's attention. Possibly the opening paragraph can be used.
* Blog author team signoffs
  * AMD Employees only: [Legal self review traffic lights completed](https://amdcloud.sharepoint.com/sites/amd-legal/Shared%20Documents/Forms/AllItems.aspx?sortField=Modified&isAscending=false&id=%2Fsites%2Famd%2Dlegal%2FShared%20Documents%2FDisclaimer%20and%20Notices%2Epdf&viewid=71efe44a%2D19a2%2D4b81%2D83df%2D05ab2f7ffa73&parent=%2Fsites%2Famd%2Dlegal%2FShared%20Documents): (edit and replace with @githubid)
  * Licenses file included for content is correct: (edit and replace with @githubid)
  * Changes from technical review and editorial team are acceptable: (edit and replace with @githubid)
